### PR TITLE
Feat: support collection of rsvp data

### DIFF
--- a/decoder/gym.go
+++ b/decoder/gym.go
@@ -393,11 +393,13 @@ func (gym *Gym) updateGymFromRsvpProto(fortData *pogo.GetEventRsvpsOutProto) *Gy
 	timeslots := make([]rsvpTimeslot, 0)
 
 	for _, timeslot := range fortData.RsvpTimeslots {
-		timeslots = append(timeslots, rsvpTimeslot{
-			Timeslot:   timeslot.TimeSlot,
-			GoingCount: timeslot.GoingCount,
-			MaybeCount: timeslot.MaybeCount,
-		})
+		if timeslot.GoingCount > 0 || timeslot.MaybeCount > 0 {
+			timeslots = append(timeslots, rsvpTimeslot{
+				Timeslot:   timeslot.TimeSlot,
+				GoingCount: timeslot.GoingCount,
+				MaybeCount: timeslot.MaybeCount,
+			})
+		}
 	}
 
 	if len(timeslots) == 0 {

--- a/decoder/gym.go
+++ b/decoder/gym.go
@@ -455,9 +455,10 @@ func hasChangesGym(old *Gym, new *Gym) bool {
 		old.PowerUpPoints != new.PowerUpPoints ||
 		old.PowerUpEndTimestamp != new.PowerUpEndTimestamp ||
 		old.Description != new.Description ||
+		old.Rsvps != new.Rsvps ||
 		!floatAlmostEqual(old.Lat, new.Lat, floatTolerance) ||
-		!floatAlmostEqual(old.Lon, new.Lon, floatTolerance) ||
-		old.Rsvps != new.Rsvps
+		!floatAlmostEqual(old.Lon, new.Lon, floatTolerance)
+
 }
 
 // hasChangesInternalGym compares two Gym structs for changes that will be stored in memory

--- a/decoder/gym.go
+++ b/decoder/gym.go
@@ -550,7 +550,7 @@ func createGymWebhooks(oldGym *Gym, gym *Gym, areas []geo.AreaName) {
 	if gym.RaidSpawnTimestamp.ValueOrZero() > 0 &&
 		(oldGym == nil || oldGym.RaidLevel != gym.RaidLevel ||
 			oldGym.RaidPokemonId != gym.RaidPokemonId ||
-			oldGym.RaidSpawnTimestamp != gym.RaidSpawnTimestamp) {
+			oldGym.RaidSpawnTimestamp != gym.RaidSpawnTimestamp || oldGym.Rsvps != gym.Rsvps) {
 		raidBattleTime := gym.RaidBattleTimestamp.ValueOrZero()
 		raidEndTime := gym.RaidEndTimestamp.ValueOrZero()
 		now := time.Now().Unix()
@@ -591,6 +591,13 @@ func createGymWebhooks(oldGym *Gym, gym *Gym, areas []geo.AreaName) {
 				"power_up_level":         gym.PowerUpLevel.ValueOrZero(),
 				"power_up_end_timestamp": gym.PowerUpEndTimestamp.ValueOrZero(),
 				"ar_scan_eligible":       gym.ArScanEligible.ValueOrZero(),
+				"rsvps": func() any {
+					if !gym.Rsvps.Valid {
+						return nil
+					} else {
+						return json.RawMessage(gym.Rsvps.ValueOrZero())
+					}
+				}(),
 			}
 
 			webhooksSender.AddMessage(webhooks.Raid, raidHook, areas)

--- a/decoder/gym.go
+++ b/decoder/gym.go
@@ -1,10 +1,12 @@
 package decoder
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	"golbat/geo"
@@ -63,6 +65,7 @@ type Gym struct {
 	PowerUpEndTimestamp    null.Int    `db:"power_up_end_timestamp"`
 	Description            null.String `db:"description"`
 	Defenders              null.String `db:"defenders"`
+	Rsvps                  null.String `db:"rsvps"`
 	//`id` varchar(35) NOT NULL,
 	//`lat` double(18,14) NOT NULL,
 	//`lon` double(18,14) NOT NULL,
@@ -380,6 +383,37 @@ func (gym *Gym) updateGymFromGetMapFortsOutProto(fortData *pogo.GetMapFortsOutPr
 	return gym
 }
 
+func (gym *Gym) updateGymFromRsvpProto(fortData *pogo.GetEventRsvpsOutProto) *Gym {
+	type rsvpTimeslot struct {
+		Timeslot   int64 `json:"timeslot"`
+		GoingCount int32 `json:"going_count"`
+		MaybeCount int32 `json:"maybe_count"`
+	}
+
+	timeslots := make([]rsvpTimeslot, 0)
+
+	for _, timeslot := range fortData.RsvpTimeslots {
+		timeslots = append(timeslots, rsvpTimeslot{
+			Timeslot:   timeslot.TimeSlot,
+			GoingCount: timeslot.GoingCount,
+			MaybeCount: timeslot.MaybeCount,
+		})
+	}
+
+	if len(timeslots) == 0 {
+		gym.Rsvps = null.NewString("", false)
+	} else {
+		slices.SortFunc(timeslots, func(a, b rsvpTimeslot) int {
+			return cmp.Compare(a.Timeslot, b.Timeslot)
+		})
+
+		bRsvps, _ := json.Marshal(timeslots)
+		gym.Rsvps = null.StringFrom(string(bRsvps))
+	}
+
+	return gym
+}
+
 // hasChangesGym compares two Gym structs
 // Float tolerance: Lat, Lon
 func hasChangesGym(old *Gym, new *Gym) bool {
@@ -420,7 +454,8 @@ func hasChangesGym(old *Gym, new *Gym) bool {
 		old.PowerUpEndTimestamp != new.PowerUpEndTimestamp ||
 		old.Description != new.Description ||
 		!floatAlmostEqual(old.Lat, new.Lat, floatTolerance) ||
-		!floatAlmostEqual(old.Lon, new.Lon, floatTolerance)
+		!floatAlmostEqual(old.Lon, new.Lon, floatTolerance) ||
+		old.Rsvps != new.Rsvps
 }
 
 // hasChangesInternalGym compares two Gym structs for changes that will be stored in memory
@@ -586,8 +621,8 @@ func saveGymRecord(ctx context.Context, db db.DbDetails, gym *Gym) {
 
 	//log.Traceln(cmp.Diff(oldGym, gym))
 	if oldGym == nil {
-		res, err := db.GeneralDb.NamedExecContext(ctx, "INSERT INTO gym (id,lat,lon,name,url,last_modified_timestamp,raid_end_timestamp,raid_spawn_timestamp,raid_battle_timestamp,updated,raid_pokemon_id,guarding_pokemon_id,guarding_pokemon_display,available_slots,team_id,raid_level,enabled,ex_raid_eligible,in_battle,raid_pokemon_move_1,raid_pokemon_move_2,raid_pokemon_form,raid_pokemon_alignment,raid_pokemon_cp,raid_is_exclusive,cell_id,deleted,total_cp,first_seen_timestamp,raid_pokemon_gender,sponsor_id,partner_id,raid_pokemon_costume,raid_pokemon_evolution,ar_scan_eligible,power_up_level,power_up_points,power_up_end_timestamp,description, defenders) "+
-			"VALUES (:id,:lat,:lon,:name,:url,UNIX_TIMESTAMP(),:raid_end_timestamp,:raid_spawn_timestamp,:raid_battle_timestamp,:updated,:raid_pokemon_id,:guarding_pokemon_id,:guarding_pokemon_display,:available_slots,:team_id,:raid_level,:enabled,:ex_raid_eligible,:in_battle,:raid_pokemon_move_1,:raid_pokemon_move_2,:raid_pokemon_form,:raid_pokemon_alignment,:raid_pokemon_cp,:raid_is_exclusive,:cell_id,0,:total_cp,UNIX_TIMESTAMP(),:raid_pokemon_gender,:sponsor_id,:partner_id,:raid_pokemon_costume,:raid_pokemon_evolution,:ar_scan_eligible,:power_up_level,:power_up_points,:power_up_end_timestamp,:description, :defenders)", gym)
+		res, err := db.GeneralDb.NamedExecContext(ctx, "INSERT INTO gym (id,lat,lon,name,url,last_modified_timestamp,raid_end_timestamp,raid_spawn_timestamp,raid_battle_timestamp,updated,raid_pokemon_id,guarding_pokemon_id,guarding_pokemon_display,available_slots,team_id,raid_level,enabled,ex_raid_eligible,in_battle,raid_pokemon_move_1,raid_pokemon_move_2,raid_pokemon_form,raid_pokemon_alignment,raid_pokemon_cp,raid_is_exclusive,cell_id,deleted,total_cp,first_seen_timestamp,raid_pokemon_gender,sponsor_id,partner_id,raid_pokemon_costume,raid_pokemon_evolution,ar_scan_eligible,power_up_level,power_up_points,power_up_end_timestamp,description, defenders, rsvps) "+
+			"VALUES (:id,:lat,:lon,:name,:url,UNIX_TIMESTAMP(),:raid_end_timestamp,:raid_spawn_timestamp,:raid_battle_timestamp,:updated,:raid_pokemon_id,:guarding_pokemon_id,:guarding_pokemon_display,:available_slots,:team_id,:raid_level,:enabled,:ex_raid_eligible,:in_battle,:raid_pokemon_move_1,:raid_pokemon_move_2,:raid_pokemon_form,:raid_pokemon_alignment,:raid_pokemon_cp,:raid_is_exclusive,:cell_id,0,:total_cp,UNIX_TIMESTAMP(),:raid_pokemon_gender,:sponsor_id,:partner_id,:raid_pokemon_costume,:raid_pokemon_evolution,:ar_scan_eligible,:power_up_level,:power_up_points,:power_up_end_timestamp,:description, :defenders, :rsvps)", gym)
 
 		statsCollector.IncDbQuery("insert gym", err)
 		if err != nil {
@@ -635,7 +670,8 @@ func saveGymRecord(ctx context.Context, db db.DbDetails, gym *Gym) {
 			"power_up_points = :power_up_points, "+
 			"power_up_end_timestamp = :power_up_end_timestamp,"+
 			"description = :description,"+
-			"defenders = :defenders "+
+			"defenders = :defenders,"+
+			"rsvps = :rsvps "+
 			"WHERE id = :id", gym,
 		)
 		statsCollector.IncDbQuery("update gym", err)
@@ -721,4 +757,25 @@ func UpdateGymRecordWithGetMapFortsOutProto(ctx context.Context, db db.DbDetails
 	gym.updateGymFromGetMapFortsOutProto(mapFort, false)
 	saveGymRecord(ctx, db, gym)
 	return true, fmt.Sprintf("%s %s", gym.Id, gym.Name.ValueOrZero())
+}
+
+func UpdateGymRecordWithRsvpProto(ctx context.Context, db db.DbDetails, req *pogo.RaidDetails, resp *pogo.GetEventRsvpsOutProto) string {
+	gymMutex, _ := gymStripedMutex.GetLock(req.FortId)
+	gymMutex.Lock()
+	defer gymMutex.Unlock()
+
+	gym, err := getGymRecord(ctx, db, req.FortId)
+	if err != nil {
+		return err.Error()
+	}
+
+	if gym == nil {
+		// Do not add RSVP details to unknown gyms
+		return fmt.Sprintf("%s Gym not present", req.FortId)
+	}
+	gym.updateGymFromRsvpProto(resp)
+
+	saveGymRecord(ctx, db, gym)
+
+	return fmt.Sprintf("%s %s", gym.Id, gym.Name.ValueOrZero())
 }

--- a/main.go
+++ b/main.go
@@ -447,6 +447,14 @@ func decode(ctx context.Context, method int, protoData *ProtoData) {
 			result = decodeTappable(ctx, protoData.Request, protoData.Data, protoData.Account, protoData.TimestampMs)
 		}
 		processed = true
+	case pogo.Method_METHOD_GET_EVENT_RSVPS:
+		if getScanParameters(protoData).ProcessGyms {
+			result = decodeGetEventRsvp(ctx, protoData.Request, protoData.Data)
+		}
+		processed = true
+	case pogo.Method_METHOD_GET_EVENT_RSVP_COUNT:
+		// We don't process the count, only the detail
+		ignore = true
 	default:
 		log.Debugf("Did not know hook type %s", pogo.Method(method))
 	}
@@ -979,4 +987,33 @@ func decodeTappable(ctx context.Context, request, data []byte, username string, 
 		result = decoder.UpdatePokemonRecordWithTappableEncounter(ctx, dbDetails, &tappableRequest, encounter, username, timestampMs)
 	}
 	return result + " " + decoder.UpdateTappable(ctx, dbDetails, &tappableRequest, &tappable, timestampMs)
+}
+
+func decodeGetEventRsvp(ctx context.Context, request []byte, data []byte) string {
+	var rsvp pogo.GetEventRsvpsOutProto
+	if err := proto.Unmarshal(data, &rsvp); err != nil {
+		log.Errorf("Failed to parse %s", err)
+		return fmt.Sprintf("Failed to parse GetEventRsvpsOutProto %s", err)
+	}
+
+	var rsvpRequest pogo.GetEventRsvpsProto
+	if request != nil {
+		if err := proto.Unmarshal(request, &rsvpRequest); err != nil {
+			log.Errorf("Failed to parse %s", err)
+			return fmt.Sprintf("Failed to parse GetEventRsvpsProto %s", err)
+		}
+	}
+
+	if rsvp.Status != pogo.GetEventRsvpsOutProto_SUCCESS {
+		return fmt.Sprintf("Ignored GetEventRsvpsOutProto non-success status %s", rsvp.Status)
+	}
+
+	switch op := rsvpRequest.EventDetails.(type) {
+	case *pogo.GetEventRsvpsProto_Raid:
+		return decoder.UpdateGymRecordWithRsvpProto(ctx, dbDetails, op.Raid, &rsvp)
+	case *pogo.GetEventRsvpsProto_GmaxBattle:
+		return "Unsupported GmaxBattle Rsvp received"
+	}
+
+	return "Failed to parse GetEventRsvpsProto - unknown event type"
 }

--- a/protos.md
+++ b/protos.md
@@ -56,6 +56,18 @@ requires the proto request to be present in the raw.
 - Decode top 3 player scores for a contest. This requires the proto request
 to be present in the raw.
 
+`Method_METHOD_PROCESS_TAPPABLE = 1408`
+
+- Decode pokemon encounters and items hidden behind tappable objects
+- 
+`Method_METHOD_GET_EVENT_RSVPS = 3031`
+
+- Decode the number of players and time that they have indicated they will present at a raid
+- 
+`Method_REQUEST_TYPE_METHOD_GET_EVENT_RSVP_COUNT = 3036`
+
+- This proto is ignored
+
 # Social actions
 
 - The master `ClientAction_CLIENT_ACTION_PROXY_SOCIAL_ACTION` proto will be

--- a/sql/46_rsvps.up.sql
+++ b/sql/46_rsvps.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE gym
+    add `rsvps` TEXT default NULL;


### PR DESCRIPTION
Record rsvps against gym table

```
[{"timeslot":1747387840273,"going_count":1,"maybe_count":0}]
```
An example query to return currently active raids with timeslots in the future:

```
select name, from_unixtime(timeslot/1000, '%H:%i:%s') as t, going_count, maybe_count
  from gym, json_table(gym.rsvps,'$[*]' columns (
    timeslot bigint path '$.timeslot', 
    going_count int path '$.going_count', 
    maybe_count int path '$.maybe_count'
    )
  ) as gt 
  where rsvps is not null 
    and gt.timeslot/1000 between raid_spawn_timestamp 
    and raid_end_timestamp and gt.timeslot/1000 > unix_timestamp();
```
(the first check is whether the timeslot is in the currently active raid, the second whether it is in the future - arguably only the second is needed but I have included for completeness of this example)